### PR TITLE
feat: align timing model with midi2 timeline

### DIFF
--- a/Tests/AnimationKitTests/AnimationCompositionTests.swift
+++ b/Tests/AnimationKitTests/AnimationCompositionTests.swift
@@ -3,21 +3,60 @@ import XCTest
 
 final class AnimationCompositionTests: XCTestCase {
     func testGroupMergesParameterStates() throws {
-        let fadeIn = Animation(duration: 1.0, opacity: Timeline([
-            Keyframe(time: 0.0, value: 0.0),
-            Keyframe(time: 1.0, value: 1.0)
-        ]))
-
-        let move = Animation(duration: 1.0, position: PositionTimeline(
-            x: Timeline([
+        let fadeInMidi = Midi2Timeline(
+            timeModel: BeatTimeModel(tempo: Tempo(beatsPerMinute: 60)),
+            tracks: [
+                Midi2AutomationTrack(
+                    target: .opacity,
+                    events: [
+                        BeatKeyframe(beat: 0.0, value: 0.0),
+                        BeatKeyframe(beat: 1.0, value: 1.0)
+                    ]
+                )
+            ]
+        )
+        let fadeIn = Animation(
+            duration: 1.0,
+            midiTimeline: fadeInMidi,
+            opacity: Timeline([
                 Keyframe(time: 0.0, value: 0.0),
-                Keyframe(time: 1.0, value: 10.0)
-            ]),
-            y: Timeline([
-                Keyframe(time: 0.0, value: 0.0),
-                Keyframe(time: 1.0, value: 5.0)
+                Keyframe(time: 1.0, value: 1.0)
             ])
-        ))
+        )
+
+        let moveMidi = Midi2Timeline(
+            timeModel: BeatTimeModel(tempo: Tempo(beatsPerMinute: 60)),
+            tracks: [
+                Midi2AutomationTrack(
+                    target: .positionX,
+                    events: [
+                        BeatKeyframe(beat: 0.0, value: 0.0),
+                        BeatKeyframe(beat: 1.0, value: 10.0)
+                    ]
+                ),
+                Midi2AutomationTrack(
+                    target: .positionY,
+                    events: [
+                        BeatKeyframe(beat: 0.0, value: 0.0),
+                        BeatKeyframe(beat: 1.0, value: 5.0)
+                    ]
+                )
+            ]
+        )
+        let move = Animation(
+            duration: 1.0,
+            midiTimeline: moveMidi,
+            position: PositionTimeline(
+                x: Timeline([
+                    Keyframe(time: 0.0, value: 0.0),
+                    Keyframe(time: 1.0, value: 10.0)
+                ]),
+                y: Timeline([
+                    Keyframe(time: 0.0, value: 0.0),
+                    Keyframe(time: 1.0, value: 5.0)
+                ])
+            )
+        )
 
         let group = Animation.group {
             fadeIn
@@ -33,15 +72,47 @@ final class AnimationCompositionTests: XCTestCase {
     }
 
     func testSequenceEvaluatesWithOffsets() throws {
-        let fadeOut = Animation(duration: 1.0, opacity: Timeline([
-            Keyframe(time: 0.0, value: 1.0),
-            Keyframe(time: 1.0, value: 0.0)
-        ]))
+        let fadeOutMidi = Midi2Timeline(
+            timeModel: BeatTimeModel(tempo: Tempo(beatsPerMinute: 60)),
+            tracks: [
+                Midi2AutomationTrack(
+                    target: .opacity,
+                    events: [
+                        BeatKeyframe(beat: 0.0, value: 1.0),
+                        BeatKeyframe(beat: 1.0, value: 0.0)
+                    ]
+                )
+            ]
+        )
+        let fadeOut = Animation(
+            duration: 1.0,
+            midiTimeline: fadeOutMidi,
+            opacity: Timeline([
+                Keyframe(time: 0.0, value: 1.0),
+                Keyframe(time: 1.0, value: 0.0)
+            ])
+        )
 
-        let scaleUp = Animation(duration: 0.5, scale: Timeline([
-            Keyframe(time: 0.0, value: 1.0),
-            Keyframe(time: 0.5, value: 2.0)
-        ]))
+        let scaleMidi = Midi2Timeline(
+            timeModel: BeatTimeModel(tempo: Tempo(beatsPerMinute: 60)),
+            tracks: [
+                Midi2AutomationTrack(
+                    target: .scale,
+                    events: [
+                        BeatKeyframe(beat: 0.0, value: 1.0),
+                        BeatKeyframe(beat: 0.5, value: 2.0)
+                    ]
+                )
+            ]
+        )
+        let scaleUp = Animation(
+            duration: 0.5,
+            midiTimeline: scaleMidi,
+            scale: Timeline([
+                Keyframe(time: 0.0, value: 1.0),
+                Keyframe(time: 0.5, value: 2.0)
+            ])
+        )
 
         let sequence = Animation.sequence {
             fadeOut
@@ -64,6 +135,18 @@ final class AnimationCompositionTests: XCTestCase {
     func testNestedCompositionsRemainDeterministic() {
         let clip = AnimationClip(
             duration: 1.0,
+            midiTimeline: Midi2Timeline(
+                timeModel: BeatTimeModel(tempo: Tempo(beatsPerMinute: 60)),
+                tracks: [
+                    Midi2AutomationTrack(
+                        target: .opacity,
+                        events: [
+                            BeatKeyframe(beat: 0.0, value: 0.0),
+                            BeatKeyframe(beat: 1.0, value: 1.0)
+                        ]
+                    )
+                ]
+            ),
             opacity: Timeline([
                 Keyframe(time: 0.0, value: 0.0),
                 Keyframe(time: 1.0, value: 1.0)
@@ -75,10 +158,25 @@ final class AnimationCompositionTests: XCTestCase {
                 Animation.clip(clip)
             }
             Animation.group {
-                Animation(duration: 0.5, rotation: Timeline([
-                    Keyframe(time: 0.0, value: 0.0),
-                    Keyframe(time: 0.5, value: Double.pi)
-                ]))
+                Animation(
+                    duration: 0.5,
+                    midiTimeline: Midi2Timeline(
+                        timeModel: BeatTimeModel(tempo: Tempo(beatsPerMinute: 60)),
+                        tracks: [
+                            Midi2AutomationTrack(
+                                target: .rotation,
+                                events: [
+                                    BeatKeyframe(beat: 0.0, value: 0.0),
+                                    BeatKeyframe(beat: 0.5, value: Double.pi)
+                                ]
+                            )
+                        ]
+                    ),
+                    rotation: Timeline([
+                        Keyframe(time: 0.0, value: 0.0),
+                        Keyframe(time: 0.5, value: Double.pi)
+                    ])
+                )
             }
         }
 

--- a/Tests/AnimationKitTests/BeatTimeTests.swift
+++ b/Tests/AnimationKitTests/BeatTimeTests.swift
@@ -39,11 +39,49 @@ final class BeatTimeTests: XCTestCase {
 
         let clip = AnimationClip(
             duration: 2.0,
+            midiTimeline: Midi2Timeline(
+                timeModel: model,
+                tracks: [
+                    Midi2AutomationTrack(
+                        target: .opacity,
+                        events: [
+                            BeatKeyframe(beat: 0.0, value: 0.0),
+                            BeatKeyframe(beat: 4.0, value: 1.0)
+                        ]
+                    )
+                ]
+            ),
             opacity: Timeline(beatTimeline: beatTimeline, model: model)
         )
 
         let state = clip.state(at: BeatTime(2.0), using: model)
         let opacity = try XCTUnwrap(state.opacity)
         XCTAssertEqual(opacity, 0.5, accuracy: 1e-9)
+    }
+
+    func testMidiTimelineEvaluatesAgainstTimeModel() throws {
+        let model = BeatTimeModel(tempo: Tempo(beatsPerMinute: 120))
+        let timeline = Midi2Timeline(
+            timeModel: model,
+            tracks: [
+                Midi2AutomationTrack(
+                    target: .scale,
+                    events: [
+                        BeatKeyframe(beat: 0.0, value: 1.0),
+                        BeatKeyframe(beat: 2.0, value: 3.0)
+                    ]
+                )
+            ]
+        )
+
+        let beatState = timeline.state(at: BeatTime(1.0))
+        let beatScale = try XCTUnwrap(beatState.scale)
+        XCTAssertEqual(beatScale, 2.0, accuracy: 1e-9)
+
+        let secondsState = timeline.state(at: 0.5)
+        let secondsScale = try XCTUnwrap(secondsState.scale)
+        XCTAssertEqual(secondsScale, 2.0, accuracy: 1e-9)
+
+        XCTAssertEqual(timeline.duration, 1.0, accuracy: 1e-9)
     }
 }

--- a/Tests/AnimationKitTests/TimelineTests.swift
+++ b/Tests/AnimationKitTests/TimelineTests.swift
@@ -28,7 +28,22 @@ final class TimelineTests: XCTestCase {
             Keyframe(time: 0.0, value: 0.0),
             Keyframe(time: 1.0, value: 1.0)
         ])
-        let anim = Animation(duration: 1.0, opacity: opacity)
+        let anim = Animation(
+            duration: 1.0,
+            midiTimeline: Midi2Timeline(
+                timeModel: BeatTimeModel(tempo: Tempo(beatsPerMinute: 60)),
+                tracks: [
+                    Midi2AutomationTrack(
+                        target: .opacity,
+                        events: [
+                            BeatKeyframe(beat: 0.0, value: 0.0),
+                            BeatKeyframe(beat: 1.0, value: 1.0)
+                        ]
+                    )
+                ]
+            ),
+            opacity: opacity
+        )
         XCTAssertEqual(anim.state(at: 0.0).opacity, 0.0)
         XCTAssertEqual(anim.state(at: 1.0).opacity, 1.0)
     }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -529,11 +529,14 @@ components:
       type: object
       required:
         - duration
+        - midiTimeline
       properties:
         duration:
           type: number
           format: double
           description: Total length of the clip in seconds.
+        midiTimeline:
+          $ref: '#/components/schemas/Midi2Timeline'
         opacity:
           $ref: '#/components/schemas/Timeline'
         position:
@@ -589,6 +592,102 @@ components:
           format: double
         easing:
           $ref: '#/components/schemas/Easing'
+    Tempo:
+      type: object
+      required:
+        - beatsPerMinute
+      properties:
+        beatsPerMinute:
+          type: number
+          format: double
+          minimum: 0.0001
+          description: Beats per minute used for beat-to-seconds conversion.
+    BeatTimeModel:
+      type: object
+      required:
+        - tempo
+      properties:
+        tempo:
+          $ref: '#/components/schemas/Tempo'
+        beatOffset:
+          type: number
+          format: double
+          default: 0
+          description: Beat value corresponding to the configured wall-time offset.
+        wallTimeOffset:
+          type: number
+          format: double
+          default: 0
+          description: Absolute time offset in seconds applied when mapping beats to wall time.
+        enableMIDI2Clock:
+          type: boolean
+          default: false
+          description: Feature flag enabling experimental MIDI 2.0 clock synchronisation.
+    BeatTimeline:
+      type: object
+      required:
+        - keyframes
+      properties:
+        keyframes:
+          type: array
+          items:
+            $ref: '#/components/schemas/BeatKeyframe'
+    BeatKeyframe:
+      type: object
+      required:
+        - beat
+        - value
+        - easing
+      properties:
+        beat:
+          type: number
+          format: double
+        value:
+          type: number
+          format: double
+        easing:
+          $ref: '#/components/schemas/Easing'
+    Midi2ControlTarget:
+      type: string
+      description: Parameter channel controlled by a midi2 automation track.
+      enum:
+        - opacity
+        - positionX
+        - positionY
+        - scale
+        - rotation
+        - colorR
+        - colorG
+        - colorB
+        - colorA
+    Midi2AutomationTrack:
+      type: object
+      required:
+        - target
+        - timeline
+      properties:
+        channel:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 255
+          description: Logical midi2 channel assigned to the automation track.
+        target:
+          $ref: '#/components/schemas/Midi2ControlTarget'
+        timeline:
+          $ref: '#/components/schemas/BeatTimeline'
+    Midi2Timeline:
+      type: object
+      required:
+        - timeModel
+        - tracks
+      properties:
+        timeModel:
+          $ref: '#/components/schemas/BeatTimeModel'
+        tracks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Midi2AutomationTrack'
     Easing:
       type: string
       enum:


### PR DESCRIPTION
## Summary
- add Midi2Timeline, automation tracks, and targets to the core timing model and surface them through AnimationClip state evaluation
- require midi timelines across the Animation DSL and client serialization, bridging to the updated OpenAPI schema
- expand the OpenAPI document and test suite to cover tempo models, beat-based evaluation, and midi-integrated animations

## Testing
- swift test


------
https://chatgpt.com/codex/tasks/task_b_68e69e88ff8c8333942c7255e4dfeead